### PR TITLE
fix bug with usage of UIViewController container api and viewDidUnload

### DIFF
--- a/CHSlideController/CHSlideController.m
+++ b/CHSlideController/CHSlideController.m
@@ -388,9 +388,6 @@
 {
     [super viewDidUnload];
     
-    [self setStaticViewController:nil];
-    [self setSlidingViewController:nil];
-    
     [_staticView removeFromSuperview];
     [_slidingView removeFromSuperview];
     


### PR DESCRIPTION
apple's document for container api is not very clear, and demo code is far from enough. The correct calling sequence should be addChildViewController + didMoveToParentViewController Or willMoveToParentViewController + removeFromParentViewController.

also, some misunderstanding with viewDidUnload,  if viewDidUnload is called, _staticViewController should be nil, after some time, viewDidLoad is expected to be recalled, but _staticViewController is still be nil
